### PR TITLE
Fix INT_REG2 macros in clock

### DIFF
--- a/include/nds/arm7/clock.h
+++ b/include/nds/arm7/clock.h
@@ -105,8 +105,8 @@ extern "C" {
 #define WRITE_INT_REG1     0x68
 #define READ_INT_REG1      0x69
 
-#define READ_INT_REG2      0x6A
-#define WRITE_INT_REG2     0x6B
+#define WRITE_INT_REG2     0x6A
+#define READ_INT_REG2      0x6B
 
 #define READ_CLOCK_ADJUST_REG  0x6C
 #define WRITE_CLOCK_ADJUST_REG 0x6D


### PR DESCRIPTION
The macros are obviously reversed (in fact, all RTC read commands must have bit 0 set).