### PR TITLE
Removed redundant code.

### DIFF
--- a/source/arm9/dldi/dldi.c
+++ b/source/arm9/dldi/dldi.c
@@ -200,7 +200,6 @@ DLDI_INTERFACE* dldiLoadFromFile (const char* path) {
 }
 
 void dldiFree (DLDI_INTERFACE* dldi) {
-	if (!dldi) return;
 	free(dldi);
 }
 


### PR DESCRIPTION
Removed null check. Note `free` is ensured to work on null pointer values by ISO C.