### PR TITLE
Improve SD read code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean:
 #-------------------------------------------------------------------------------
 dist-src:
 #-------------------------------------------------------------------------------
-	@tar --exclude=*CVS* --exclude=.svn -cjf libnds-src-$(VERSION).tar.bz2 arm7/Makefile arm9/Makefile source include icon.bmp Makefile libnds_license.txt libnds.dox
+	@tar --exclude=*CVS* --exclude=.svn -cjf libnds-src-$(VERSION).tar.bz2 arm7/Makefile arm9/Makefile source include icon.bmp Makefile libnds_license.txt Doxyfile
 
 #-------------------------------------------------------------------------------
 dist-bin: all

--- a/include/nds/arm7/sdmmc.h
+++ b/include/nds/arm7/sdmmc.h
@@ -105,7 +105,8 @@
 #define TMIO_MASK_WRITEOP (TMIO_STAT1_TXRQ | TMIO_STAT1_DATAEND)
 
 typedef struct mmcdevice {
-    u8* data;
+	u8* rData;
+	const u8* tData;
     u32 size;
     u32 error;
     u16 stat0;

--- a/include/nds/arm7/sdmmc.h
+++ b/include/nds/arm7/sdmmc.h
@@ -108,6 +108,8 @@ typedef struct mmcdevice {
 	u8* rData;
 	const u8* tData;
     u32 size;
+    u32 startOffset;
+    u32 endOffset;
     u32 error;
     u16 stat0;
     u16 stat1;

--- a/source/arm7/sdmmc.twl.c
+++ b/source/arm7/sdmmc.twl.c
@@ -42,132 +42,393 @@ void setTarget(struct mmcdevice *ctx) {
 //---------------------------------------------------------------------------------
 void sdmmc_send_command(struct mmcdevice *ctx, uint32_t cmd, uint32_t args) {
 //---------------------------------------------------------------------------------
-	int i;
-    bool getSDRESP = (cmd << 15) >> 31;
-    uint16_t flags = (cmd << 15) >> 31;
-    const bool readdata = cmd & 0x20000;
-    const bool writedata = cmd & 0x40000;
+	const bool getSDRESP = (cmd << 15) >> 31;
+	u16 flags = (cmd << 15) >> 31;
+	const bool readdata = cmd & 0x20000;
+	const bool writedata = cmd & 0x40000;
 
-    if(readdata || writedata)
-    {
-        flags |= TMIO_STAT0_DATAEND;
-    }
+	if(readdata || writedata)
+	{
+		flags |= TMIO_STAT0_DATAEND;
+	}
 
-    ctx->error = 0;
-    while((sdmmc_read16(REG_SDSTATUS1) & TMIO_STAT1_CMD_BUSY)); //mmc working?
-    sdmmc_write16(REG_SDIRMASK0,0);
-    sdmmc_write16(REG_SDIRMASK1,0);
-    sdmmc_write16(REG_SDSTATUS0,0);
-    sdmmc_write16(REG_SDSTATUS1,0);
+	ctx->error = 0;
+	while((sdmmc_read16(REG_SDSTATUS1) & TMIO_STAT1_CMD_BUSY)); //mmc working?
+	sdmmc_write16(REG_SDIRMASK0,0);
+	sdmmc_write16(REG_SDIRMASK1,0);
+	sdmmc_write16(REG_SDSTATUS0,0);
+	sdmmc_write16(REG_SDSTATUS1,0);
+	sdmmc_mask16(REG_SDDATACTL32,0x1800,0x400); // Disable TX32RQ and RX32RDY IRQ. Clear fifo.
+	sdmmc_write16(REG_SDCMDARG0,args &0xFFFF);
+	sdmmc_write16(REG_SDCMDARG1,args >> 16);
+	sdmmc_write16(REG_SDCMD,cmd &0xFFFF);
+
+	u32 size = ctx->size;
+	const u16 blkSize = sdmmc_read16(REG_SDBLKLEN32);
+	u32 *rDataPtr32 = (u32*)ctx->rData;
+	u8  *rDataPtr8  = ctx->rData;
+	const u32 *tDataPtr32 = (u32*)ctx->tData;
+	const u8  *tDataPtr8  = ctx->tData;
+
+	bool rUseBuf = ( NULL != rDataPtr32 );
+	bool tUseBuf = ( NULL != tDataPtr32 );
+
+	u16 status0 = 0;
+	while(1)
+	{
+		volatile u16 status1 = sdmmc_read16(REG_SDSTATUS1);
 #ifdef DATA32_SUPPORT
-//  if(readdata)sdmmc_mask16(REG_DATACTL32, 0x1000, 0x800);
-//  if(writedata)sdmmc_mask16(REG_DATACTL32, 0x800, 0x1000);
-//  sdmmc_mask16(REG_DATACTL32,0x1800,2);
+		volatile u16 ctl32 = sdmmc_read16(REG_SDDATACTL32);
+		if((ctl32 & 0x100))
 #else
-    sdmmc_mask16(REG_DATACTL32,0x1800,0);
+		if((status1 & TMIO_STAT1_RXRDY))
 #endif
-    sdmmc_write16(REG_SDCMDARG0,args &0xFFFF);
-    sdmmc_write16(REG_SDCMDARG1,args >> 16);
-    sdmmc_write16(REG_SDCMD,cmd &0xFFFF);
+		{
+			if(readdata)
+			{
+				if(rUseBuf)
+				{
+					sdmmc_mask16(REG_SDSTATUS1, TMIO_STAT1_RXRDY, 0);
+					if(size >= blkSize)
+					{
+						#ifdef DATA32_SUPPORT
+						if(!((u32)rDataPtr32 & 3))
+						{
+							for(u32 i = 0; i < blkSize; i += 4)
+							{
+								*rDataPtr32++ = sdmmc_read32(REG_SDFIFO32);
+							}
+						}
+						else
+						{
+							for(u32 i = 0; i < blkSize; i += 4)
+							{
+								u32 data = sdmmc_read32(REG_SDFIFO32);
+								*rDataPtr8++ = data;
+								*rDataPtr8++ = data >> 8;
+								*rDataPtr8++ = data >> 16;
+								*rDataPtr8++ = data >> 24;
+							}
+						}
+						#else
+						if(!((u32)rDataPtr16 & 1))
+						{
+							for(u32 i = 0; i < blkSize; i += 4)
+							{
+								*rDataPtr16++ = sdmmc_read16(REG_SDFIFO);
+							}
+						}
+						else
+						{
+							for(u32 i = 0; i < blkSize; i += 4)
+							{
+								u16 data = sdmmc_read16(REG_SDFIFO);
+								*rDataPtr8++ = data;
+								*rDataPtr8++ = data >> 8;
+							}
+						}
+						#endif
+						size -= blkSize;
+					}
+				}
 
-    uint32_t size = ctx->size;
-    uint16_t *dataPtr = (uint16_t*)ctx->data;
-    uint32_t *dataPtr32 = (uint32_t*)ctx->data;
-
-    bool useBuf = ( NULL != dataPtr );
-    bool useBuf32 = (useBuf && (0 == (3 & ((uint32_t)dataPtr))));
-
-    uint16_t status0 = 0;
-
-    while(1) {
-        volatile uint16_t status1 = sdmmc_read16(REG_SDSTATUS1);
+				sdmmc_mask16(REG_SDDATACTL32, 0x800, 0);
+			}
+		}
 #ifdef DATA32_SUPPORT
-        volatile uint16_t ctl32 = sdmmc_read16(REG_SDDATACTL32);
-        if((ctl32 & 0x100))
+		if(!(ctl32 & 0x200))
 #else
-        if((status1 & TMIO_STAT1_RXRDY))
+		if((status1 & TMIO_STAT1_TXRQ))
 #endif
-        {
-            if(readdata) {
-                if(useBuf) {
-                    sdmmc_mask16(REG_SDSTATUS1, TMIO_STAT1_RXRDY, 0);
-                    if(size > 0x1FF) {
-#ifdef DATA32_SUPPORT
-                        if(useBuf32) {
-                            for(i = 0; i<0x200; i+=4) {
-                                *dataPtr32++ = sdmmc_read32(REG_SDFIFO32);
-                            }
-                        } else {
-#endif
-                            for(i = 0; i<0x200; i+=2) {
-                                *dataPtr++ = sdmmc_read16(REG_SDFIFO);
-                            }
-#ifdef DATA32_SUPPORT
-                        }
-#endif
-                        size -= 0x200;
-                    }
-                }
+		{
+			if(writedata)
+			{
+				if(tUseBuf)
+				{
+					sdmmc_mask16(REG_SDSTATUS1, TMIO_STAT1_TXRQ, 0);
+					if(size >= blkSize)
+					{
+						#ifdef DATA32_SUPPORT
+						if(!((u32)tDataPtr32 & 3))
+						{
+							for(u32 i = 0; i < blkSize; i += 4)
+							{
+								sdmmc_write32(REG_SDFIFO32, *tDataPtr32++);
+							}
+						}
+						else
+						{
+							for(u32 i = 0; i < blkSize; i += 4)
+							{
+								u32 data = *tDataPtr8++;
+								data |= (u32)*tDataPtr8++ << 8;
+								data |= (u32)*tDataPtr8++ << 16;
+								data |= (u32)*tDataPtr8++ << 24;
+								sdmmc_write32(REG_SDFIFO32, data);
+							}
+						}
+						#else
+						if(!((u32)tDataPtr16 & 1))
+						{
+							for(u32 i = 0; i < blkSize; i += 2)
+							{
+								sdmmc_write16(REG_SDFIFO, *tDataPtr16++);
+							}
+						}
+						else
+						{
+							for(u32 i = 0; i < blkSize; i += 2)
+							{
+								u16 data = *tDataPtr8++;
+								data |= (u16)(*tDataPtr8++ << 8);
+								sdmmc_write16(REG_SDFIFO, data);
+							}
+						}
+						#endif
+						size -= blkSize;
+					}
+				}
 
-                sdmmc_mask16(REG_SDDATACTL32, 0x800, 0);
-            }
-        }
+				sdmmc_mask16(REG_SDDATACTL32, 0x1000, 0);
+			}
+		}
+		if(status1 & TMIO_MASK_GW)
+		{
+			ctx->error |= 4;
+			break;
+		}
+
+		if(!(status1 & TMIO_STAT1_CMD_BUSY))
+		{
+			status0 = sdmmc_read16(REG_SDSTATUS0);
+			if(sdmmc_read16(REG_SDSTATUS0) & TMIO_STAT0_CMDRESPEND)
+			{
+				ctx->error |= 0x1;
+			}
+			if(status0 & TMIO_STAT0_DATAEND)
+			{
+				ctx->error |= 0x2;
+			}
+
+			if((status0 & flags) == flags)
+				break;
+		}
+	}
+	ctx->stat0 = sdmmc_read16(REG_SDSTATUS0);
+	ctx->stat1 = sdmmc_read16(REG_SDSTATUS1);
+	sdmmc_write16(REG_SDSTATUS0,0);
+	sdmmc_write16(REG_SDSTATUS1,0);
+
+	if(getSDRESP != 0)
+	{
+		ctx->ret[0] = (u32)(sdmmc_read16(REG_SDRESP0) | (sdmmc_read16(REG_SDRESP1) << 16));
+		ctx->ret[1] = (u32)(sdmmc_read16(REG_SDRESP2) | (sdmmc_read16(REG_SDRESP3) << 16));
+		ctx->ret[2] = (u32)(sdmmc_read16(REG_SDRESP4) | (sdmmc_read16(REG_SDRESP5) << 16));
+		ctx->ret[3] = (u32)(sdmmc_read16(REG_SDRESP6) | (sdmmc_read16(REG_SDRESP7) << 16));
+	}
+}
+
+//---------------------------------------------------------------------------------
+void sdmmc_send_command_ndma(struct mmcdevice *ctx, u32 cmd, u32 args)
+//---------------------------------------------------------------------------------
+{
+	*(u32*)(0x4004104) = 0x0400490C;
+	*(u32*)(0x4004108) = (u32)ctx->rData;
+	
+	*(u32*)(0x400410C) = ctx->size;
+	
+	*(u32*)(0x4004110) = 0x80;
+	
+	*(u32*)(0x4004114) = 0x1;
+	
+	*(u32*)(0x400411C) = 0xC8004000;
+
+
+	const bool getSDRESP = (cmd << 15) >> 31;
+	u16 flags = (cmd << 15) >> 31;
+	const bool readdata = cmd & 0x20000;
+	const bool writedata = cmd & 0x40000;
+
+	if(readdata || writedata)
+	{
+		flags |= TMIO_STAT0_DATAEND;
+	}
+
+	ctx->error = 0;
+	while((sdmmc_read16(REG_SDSTATUS1) & TMIO_STAT1_CMD_BUSY)); //mmc working?
+	sdmmc_write16(REG_SDIRMASK0,0);
+	sdmmc_write16(REG_SDIRMASK1,0);
+	sdmmc_write16(REG_SDSTATUS0,0);
+	sdmmc_write16(REG_SDSTATUS1,0);
+	sdmmc_mask16(REG_SDDATACTL32,0x1800,0x400); // Disable TX32RQ and RX32RDY IRQ. Clear fifo.
+	sdmmc_write16(REG_SDCMDARG0,args &0xFFFF);
+	sdmmc_write16(REG_SDCMDARG1,args >> 16);
+	sdmmc_write16(REG_SDCMD,cmd &0xFFFF);
+
+	u32 size = ctx->size;
+	const u16 blkSize = sdmmc_read16(REG_SDBLKLEN32);
+	u32 *rDataPtr32 = (u32*)ctx->rData;
+	//u8  *rDataPtr8  = ctx->rData;
+	const u32 *tDataPtr32 = (u32*)ctx->tData;
+	const u8  *tDataPtr8  = ctx->tData;
+
+	bool rUseBuf = ( NULL != rDataPtr32 );
+	bool tUseBuf = ( NULL != tDataPtr32 );
+
+	u16 status0 = 0;
+	while(1)
+	{
+		volatile u16 status1 = sdmmc_read16(REG_SDSTATUS1);
 #ifdef DATA32_SUPPORT
-        if(!(ctl32 & 0x200))
+		volatile u16 ctl32 = sdmmc_read16(REG_SDDATACTL32);
+		if((ctl32 & 0x100))
 #else
-        if((status1 & TMIO_STAT1_TXRQ))
+		if((status1 & TMIO_STAT1_RXRDY))
 #endif
-        {
-            if(writedata) {
-                if(useBuf) {
-                    sdmmc_mask16(REG_SDSTATUS1, TMIO_STAT1_TXRQ, 0);
-                    //sdmmc_write16(REG_SDSTATUS1,~TMIO_STAT1_TXRQ);
-                    if(size > 0x1FF) {
+		{
+			if(readdata)
+			{
+				if(rUseBuf)
+				{
+					sdmmc_mask16(REG_SDSTATUS1, TMIO_STAT1_RXRDY, 0);
+					if(size >= blkSize)
+					{
+						#ifdef DATA32_SUPPORT
+						if(!((u32)rDataPtr32 & 3))
+						{
+							//for(u32 i = 0; i < blkSize; i += 4)
+							//{
+							//	*rDataPtr32++ = sdmmc_read32(REG_SDFIFO32);
+							//}
+						}
+						else
+						{
+							//for(u32 i = 0; i < blkSize; i += 4)
+							//{
+							//	u32 data = sdmmc_read32(REG_SDFIFO32);
+							//	*rDataPtr8++ = data;
+							//	*rDataPtr8++ = data >> 8;
+							//	*rDataPtr8++ = data >> 16;
+							//	*rDataPtr8++ = data >> 24;
+							//}
+						}
+						#else
+						if(!((u32)rDataPtr16 & 1))
+						{
+							//for(u32 i = 0; i < blkSize; i += 4)
+							//{
+							//	*rDataPtr16++ = sdmmc_read16(REG_SDFIFO);
+							//}
+						}
+						else
+						{
+							//for(u32 i = 0; i < blkSize; i += 4)
+							//{
+							//	u16 data = sdmmc_read16(REG_SDFIFO);
+							//	*rDataPtr8++ = data;
+							//	*rDataPtr8++ = data >> 8;
+							//}
+						}
+						#endif
+						size -= blkSize;
+					}
+				}
+
+				sdmmc_mask16(REG_SDDATACTL32, 0x800, 0);
+			}
+		}
 #ifdef DATA32_SUPPORT
-                        for(i = 0; i<0x200; i+=4) {
-                            sdmmc_write32(REG_SDFIFO32,*dataPtr32++);
-                        }
+		if(!(ctl32 & 0x200))
 #else
-                        for(i = 0; i<0x200; i+=2) {
-                            sdmmc_write16(REG_SDFIFO,*dataPtr++);
-                        }
+		if((status1 & TMIO_STAT1_TXRQ))
 #endif
-                        size -= 0x200;
-                    }
-                }
+		{
+			if(writedata)
+			{
+				if(tUseBuf)
+				{
+					sdmmc_mask16(REG_SDSTATUS1, TMIO_STAT1_TXRQ, 0);
+					if(size >= blkSize)
+					{
+						#ifdef DATA32_SUPPORT
+						if(!((u32)tDataPtr32 & 3))
+						{
+							for(u32 i = 0; i < blkSize; i += 4)
+							{
+								sdmmc_write32(REG_SDFIFO32, *tDataPtr32++);
+							}
+						}
+						else
+						{
+							for(u32 i = 0; i < blkSize; i += 4)
+							{
+								u32 data = *tDataPtr8++;
+								data |= (u32)*tDataPtr8++ << 8;
+								data |= (u32)*tDataPtr8++ << 16;
+								data |= (u32)*tDataPtr8++ << 24;
+								sdmmc_write32(REG_SDFIFO32, data);
+							}
+						}
+						#else
+						if(!((u32)tDataPtr16 & 1))
+						{
+							for(u32 i = 0; i < blkSize; i += 2)
+							{
+								sdmmc_write16(REG_SDFIFO, *tDataPtr16++);
+							}
+						}
+						else
+						{
+							for(u32 i = 0; i < blkSize; i += 2)
+							{
+								u16 data = *tDataPtr8++;
+								data |= (u16)(*tDataPtr8++ << 8);
+								sdmmc_write16(REG_SDFIFO, data);
+							}
+						}
+						#endif
+						size -= blkSize;
+					}
+				}
 
-                sdmmc_mask16(REG_SDDATACTL32, 0x1000, 0);
-            }
-        }
-        if(status1 & TMIO_MASK_GW) {
-            ctx->error |= 4;
-            break;
-        }
+				sdmmc_mask16(REG_SDDATACTL32, 0x1000, 0);
+			}
+		}
+		if(status1 & TMIO_MASK_GW)
+		{
+			ctx->error |= 4;
+			break;
+		}
 
-        if(!(status1 & TMIO_STAT1_CMD_BUSY)) {
-            status0 = sdmmc_read16(REG_SDSTATUS0);
-            if(sdmmc_read16(REG_SDSTATUS0) & TMIO_STAT0_CMDRESPEND) {
-                ctx->error |= 0x1;
-            }
-            if(status0 & TMIO_STAT0_DATAEND) {
-                ctx->error |= 0x2;
-            }
+		if(!(status1 & TMIO_STAT1_CMD_BUSY))
+		{
+			status0 = sdmmc_read16(REG_SDSTATUS0);
+			if(sdmmc_read16(REG_SDSTATUS0) & TMIO_STAT0_CMDRESPEND)
+			{
+				ctx->error |= 0x1;
+			}
+			if(status0 & TMIO_STAT0_DATAEND)
+			{
+				ctx->error |= 0x2;
+			}
 
-            if((status0 & flags) == flags)
-                break;
-        }
-    }
-    ctx->stat0 = sdmmc_read16(REG_SDSTATUS0);
-    ctx->stat1 = sdmmc_read16(REG_SDSTATUS1);
-    sdmmc_write16(REG_SDSTATUS0,0);
-    sdmmc_write16(REG_SDSTATUS1,0);
+			if((status0 & flags) == flags)
+				break;
+		}
+	}
+	ctx->stat0 = sdmmc_read16(REG_SDSTATUS0);
+	ctx->stat1 = sdmmc_read16(REG_SDSTATUS1);
+	sdmmc_write16(REG_SDSTATUS0,0);
+	sdmmc_write16(REG_SDSTATUS1,0);
 
-    if(getSDRESP != 0) {
-        ctx->ret[0] = sdmmc_read16(REG_SDRESP0) | (sdmmc_read16(REG_SDRESP1) << 16);
-        ctx->ret[1] = sdmmc_read16(REG_SDRESP2) | (sdmmc_read16(REG_SDRESP3) << 16);
-        ctx->ret[2] = sdmmc_read16(REG_SDRESP4) | (sdmmc_read16(REG_SDRESP5) << 16);
-        ctx->ret[3] = sdmmc_read16(REG_SDRESP6) | (sdmmc_read16(REG_SDRESP7) << 16);
-    }
+	if(getSDRESP != 0)
+	{
+		ctx->ret[0] = (u32)(sdmmc_read16(REG_SDRESP0) | (sdmmc_read16(REG_SDRESP1) << 16));
+		ctx->ret[1] = (u32)(sdmmc_read16(REG_SDRESP2) | (sdmmc_read16(REG_SDRESP3) << 16));
+		ctx->ret[2] = (u32)(sdmmc_read16(REG_SDRESP4) | (sdmmc_read16(REG_SDRESP5) << 16));
+		ctx->ret[3] = (u32)(sdmmc_read16(REG_SDRESP6) | (sdmmc_read16(REG_SDRESP7) << 16));
+	}
+	*(u32*)(0x400411C) = 0x48004000;
 }
 
 
@@ -272,8 +533,9 @@ static u32 calcSDSize(u8* csd, int type) {
 //---------------------------------------------------------------------------------
 int sdmmc_sdcard_init() {
 //---------------------------------------------------------------------------------
+	// We need to send at least 74 clock pulses.
     setTarget(&deviceSD);
-    swiDelay(0xF000);
+	swiDelay(0x1980); // ~75-76 clocks
 
     // card reset
     sdmmc_send_command(&deviceSD,0,0);
@@ -303,41 +565,59 @@ int sdmmc_sdcard_init() {
     if (deviceSD.error & 0x4) return -1;
 
     sdmmc_send_command(&deviceSD,0x10403,0);
-    if (deviceSD.error & 0x4) return -1;
+    if (deviceSD.error & 0x4) return -2;
     deviceSD.initarg = deviceSD.ret[0] >> 0x10;
 
     sdmmc_send_command(&deviceSD,0x10609,deviceSD.initarg << 0x10);
-    if (deviceSD.error & 0x4) return -1;
+    if (deviceSD.error & 0x4) return -3;
 
+	// Command Class 10 support
+	const bool cmd6Supported = ((u8*)deviceSD.ret)[10] & 0x40;
     deviceSD.total_size = calcSDSize((u8*)&deviceSD.ret[0],-1);
-    deviceSD.clk = 1;
-    setckl(1);
+    setckl(0x201); // 16.756991 MHz
 
     sdmmc_send_command(&deviceSD,0x10507,deviceSD.initarg << 0x10);
-    if (deviceSD.error & 0x4) return -1;
+    if (deviceSD.error & 0x4) return -4;
 
     // CMD55
     sdmmc_send_command(&deviceSD,0x10437,deviceSD.initarg << 0x10);
-    if (deviceSD.error & 0x4) return -1;
+    if (deviceSD.error & 0x4) return -5;
 
     // ACMD42
     sdmmc_send_command(&deviceSD,0x1076A,0x0);
-    if (deviceSD.error & 0x4) return -1;
+    if (deviceSD.error & 0x4) return -6;
 
     // CMD55
     sdmmc_send_command(&deviceSD,0x10437,deviceSD.initarg << 0x10);
-    if (deviceSD.error & 0x4) return -1;
+    if (deviceSD.error & 0x4) return -7;
 
     deviceSD.SDOPT = 1;
     sdmmc_send_command(&deviceSD,0x10446,0x2);
-    if (deviceSD.error & 0x4) return -1;
+    if (deviceSD.error & 0x4) return -8;
+	sdmmc_mask16(REG_SDOPT, 0x8000, 0); // Switch to 4 bit mode.
+
+	// TODO: CMD6 to switch to high speed mode.
+	if(cmd6Supported)
+	{
+		sdmmc_write16(REG_SDSTOP,0);
+		sdmmc_write16(REG_SDBLKLEN32,64);
+		sdmmc_write16(REG_SDBLKLEN,64);
+		deviceSD.rData = NULL;
+		deviceSD.size = 64;
+		sdmmc_send_command(&deviceSD,0x31C06,0x80FFFFF1);
+		sdmmc_write16(REG_SDBLKLEN,512);
+		if(deviceSD.error & 0x4) return -9;
+
+		deviceSD.clk = 0x200; // 33.513982 MHz
+		setckl(0x200);
+	}
+	else deviceSD.clk = 0x201; // 16.756991 MHz
 
     sdmmc_send_command(&deviceSD,0x1040D,deviceSD.initarg << 0x10);
-    if (deviceSD.error & 0x4) return -1;
+    if (deviceSD.error & 0x4) return -9;
 
     sdmmc_send_command(&deviceSD,0x10410,0x200);
-    if (deviceSD.error & 0x4) return -1;
-    deviceSD.clk |= 0x200;
+    if (deviceSD.error & 0x4) return -10;
 
     return 0;
 
@@ -408,9 +688,9 @@ int sdmmc_readsectors(struct mmcdevice *device, u32 sector_no, u32 numsectors, v
 #endif
 
     sdmmc_write16(REG_SDBLKCOUNT,numsectors);
-    device->data = out;
+    device->rData = out;
     device->size = numsectors << 9;
-    sdmmc_send_command(device,0x33C12,sector_no);
+    sdmmc_send_command_ndma(device,0x33C12,sector_no);
     setTarget(&deviceSD);
     return geterror(device);
 }
@@ -429,7 +709,7 @@ int sdmmc_writesectors(struct mmcdevice *device, u32 sector_no, u32 numsectors, 
 #endif
 
     sdmmc_write16(REG_SDBLKCOUNT,numsectors);
-    device->data = in;
+    device->tData = in;
     device->size = numsectors << 9;
     sdmmc_send_command(device,0x52C19,sector_no);
     setTarget(&deviceSD);

--- a/source/arm7/sdmmc.twl.c
+++ b/source/arm7/sdmmc.twl.c
@@ -92,25 +92,84 @@ void sdmmc_send_command(struct mmcdevice *ctx, uint32_t cmd, uint32_t args) {
 					if(size >= blkSize)
 					{
 						#ifdef DATA32_SUPPORT
+                        // skip startOffset bytes at the beggining of the read
+                        if(ctx->startOffset>0)
+                        {
+                            u32 skipped=0;
+                            for(u32 skipped = 0; skipped < ctx->startOffset; skipped += 4)
+                            {
+                                sdmmc_read32(REG_SDFIFO32);        
+                            }
+                            u32 remain = ctx->startOffset-skipped;
+                            if(remain>0)
+                            {
+                                u32 data = sdmmc_read32(REG_SDFIFO32);
+                                u8 data8[4];
+                                u8* pdata8 = data8;
+                                *pdata8++ = data;
+    							*pdata8++ = data >> 8;
+    							*pdata8++ = data >> 16;
+    							*pdata8++ = data >> 24;
+    							pdata8 = data8;
+                                for (int i=0; i<remain; i++)
+                                {
+                                    pdata8++;        
+                                }
+                                for (int i=0; i<4-remain; i++)
+                                {
+                                    *rDataPtr8++ = *pdata8++;
+                                }     
+                            }
+                        }
+                        // copy data
+                        u32 copied = 0;
 						if(!((u32)rDataPtr32 & 3))
 						{
-							for(u32 i = 0; i < blkSize; i += 4)
+							for(int i = 0; i < blkSize-ctx->startOffset-ctx->endOffset; i += 4)
 							{
 								*rDataPtr32++ = sdmmc_read32(REG_SDFIFO32);
+								copied+=4;
 							}
 						}
 						else
 						{
-							for(u32 i = 0; i < blkSize; i += 4)
+							for(int i = 0; i < blkSize-ctx->startOffset-ctx->endOffset; i += 4)
 							{
 								u32 data = sdmmc_read32(REG_SDFIFO32);
 								*rDataPtr8++ = data;
 								*rDataPtr8++ = data >> 8;
 								*rDataPtr8++ = data >> 16;
 								*rDataPtr8++ = data >> 24;
+								copied+=4;
 							}
 						}
+                        // skip endOffset bytes at the end of the read
+                        if(ctx->endOffset>0)
+                        {
+                          u32 remain = blkSize-ctx->startOffset-ctx->endOffset-copied;
+                          if(remain)
+                          {
+                                u32 data = sdmmc_read32(REG_SDFIFO32);
+                                u8 data8[4];
+                                u8* pdata8 = data8;
+                                *pdata8++ = data;
+                                *pdata8++ = data >> 8;
+                                *pdata8++ = data >> 16;
+                                *pdata8++ = data >> 24;
+                                pdata8 = data8;
+                                for (int i=0; i<remain; i++)
+                                {
+                                    *rDataPtr8++ = *pdata8++;
+                                }                                
+                          }                          
+                          for(u32 skipped=4-remain; skipped < ctx->endOffset; skipped += 4)
+                          {
+                              sdmmc_read32(REG_SDFIFO32);        
+                          }
+                        }
 						#else
+                        // startOffset & endOffset NOT IMPLEMENTED in DATA16 mode
+                        // copy data : this code seems wrong
 						if(!((u32)rDataPtr16 & 1))
 						{
 							for(u32 i = 0; i < blkSize; i += 4)
@@ -226,6 +285,244 @@ void sdmmc_send_command(struct mmcdevice *ctx, uint32_t cmd, uint32_t args) {
 		ctx->ret[2] = (u32)(sdmmc_read16(REG_SDRESP4) | (sdmmc_read16(REG_SDRESP5) << 16));
 		ctx->ret[3] = (u32)(sdmmc_read16(REG_SDRESP6) | (sdmmc_read16(REG_SDRESP7) << 16));
 	}
+}
+
+//---------------------------------------------------------------------------------
+void sdmmc_send_command_nonblocking_ndma(struct mmcdevice *ctx, u32 cmd, u32 args)
+//---------------------------------------------------------------------------------
+{
+	*(u32*)(0x4004104) = 0x0400490C;
+	*(u32*)(0x4004108) = (u32)ctx->rData;
+	
+	*(u32*)(0x400410C) = ctx->size;
+	
+	*(u32*)(0x4004110) = 0x80;
+	
+	*(u32*)(0x4004114) = 0x1;
+	
+	*(u32*)(0x400411C) = 0xC8004000;
+
+	const bool getSDRESP = (cmd << 15) >> 31;
+	u16 flags = (cmd << 15) >> 31;
+	const bool readdata = cmd & 0x20000;
+	const bool writedata = cmd & 0x40000;
+
+	if(readdata || writedata)
+	{
+		flags |= TMIO_STAT0_DATAEND;
+	}
+
+	ctx->error = 0;
+	while((sdmmc_read16(REG_SDSTATUS1) & TMIO_STAT1_CMD_BUSY)); //mmc working?
+	sdmmc_write16(REG_SDIRMASK0,0);
+	sdmmc_write16(REG_SDIRMASK1,0);
+	sdmmc_write16(REG_SDSTATUS0,0);
+	sdmmc_write16(REG_SDSTATUS1,0);
+	sdmmc_mask16(REG_SDDATACTL32,0x1800,0x400); // Disable TX32RQ and RX32RDY IRQ. Clear fifo.
+	sdmmc_write16(REG_SDCMDARG0,args &0xFFFF);
+	sdmmc_write16(REG_SDCMDARG1,args >> 16);
+	sdmmc_write16(REG_SDCMD,cmd &0xFFFF);
+
+	u32 size = ctx->size;
+	const u16 blkSize = sdmmc_read16(REG_SDBLKLEN32);
+	u32 *rDataPtr32 = (u32*)ctx->rData;
+	//u8  *rDataPtr8  = ctx->rData;
+	const u32 *tDataPtr32 = (u32*)ctx->tData;
+	const u8  *tDataPtr8  = ctx->tData;
+
+	bool rUseBuf = ( NULL != rDataPtr32 );
+	bool tUseBuf = ( NULL != tDataPtr32 );
+
+    
+	u16 status0 = 0;
+	while(1)
+	{
+		volatile u16 status1 = sdmmc_read16(REG_SDSTATUS1);
+#ifdef DATA32_SUPPORT
+		volatile u16 ctl32 = sdmmc_read16(REG_SDDATACTL32);
+		if((ctl32 & 0x100))
+#else
+		if((status1 & TMIO_STAT1_RXRDY))
+#endif
+		{
+            /*
+            // should not be needed : ndma unit is taking care of data transfer
+			if(readdata)
+			{
+				if(rUseBuf)
+				{
+					sdmmc_mask16(REG_SDSTATUS1, TMIO_STAT1_RXRDY, 0);
+					if(size >= blkSize)
+					{
+						size -= blkSize;
+					}
+				}
+
+				sdmmc_mask16(REG_SDDATACTL32, 0x800, 0);
+			}*/
+		}
+#ifdef DATA32_SUPPORT
+		if(!(ctl32 & 0x200))
+#else
+		if((status1 & TMIO_STAT1_TXRQ))
+#endif
+		{
+			if(writedata)
+			{
+				if(tUseBuf)
+				{
+					sdmmc_mask16(REG_SDSTATUS1, TMIO_STAT1_TXRQ, 0);
+					if(size >= blkSize)
+					{
+						#ifdef DATA32_SUPPORT
+						if(!((u32)tDataPtr32 & 3))
+						{
+							for(u32 i = 0; i < blkSize; i += 4)
+							{
+								sdmmc_write32(REG_SDFIFO32, *tDataPtr32++);
+							}
+						}
+						else
+						{
+							for(u32 i = 0; i < blkSize; i += 4)
+							{
+								u32 data = *tDataPtr8++;
+								data |= (u32)*tDataPtr8++ << 8;
+								data |= (u32)*tDataPtr8++ << 16;
+								data |= (u32)*tDataPtr8++ << 24;
+								sdmmc_write32(REG_SDFIFO32, data);
+							}
+						}
+						#else
+						if(!((u32)tDataPtr16 & 1))
+						{
+							for(u32 i = 0; i < blkSize; i += 2)
+							{
+								sdmmc_write16(REG_SDFIFO, *tDataPtr16++);
+							}
+						}
+						else
+						{
+							for(u32 i = 0; i < blkSize; i += 2)
+							{
+								u16 data = *tDataPtr8++;
+								data |= (u16)(*tDataPtr8++ << 8);
+								sdmmc_write16(REG_SDFIFO, data);
+							}
+						}
+						#endif
+						size -= blkSize;
+					}
+				}
+
+				sdmmc_mask16(REG_SDDATACTL32, 0x1000, 0);
+			}
+		}
+		if(status1 & TMIO_MASK_GW)
+		{
+			ctx->error |= 4;
+			break;
+		}
+        
+        if(status1 & TMIO_STAT1_CMD_BUSY)
+		{
+            // command is ongoing : return
+            break;
+		} 
+        else 
+        {
+            // command is finished already without going busy : return
+            // not supposed to happen
+            // needed for no$gba only
+            /*status0 = sdmmc_read16(REG_SDSTATUS0);
+            if((status0 & flags) == flags)
+            break;*/
+		}		
+	}
+	//ctx->stat0 = sdmmc_read16(REG_SDSTATUS0);
+	//ctx->stat1 = sdmmc_read16(REG_SDSTATUS1);
+	//sdmmc_write16(REG_SDSTATUS0,0);
+	//sdmmc_write16(REG_SDSTATUS1,0);
+
+	/*if(getSDRESP != 0)
+	{
+		ctx->ret[0] = (u32)(sdmmc_read16(REG_SDRESP0) | (sdmmc_read16(REG_SDRESP1) << 16));
+		ctx->ret[1] = (u32)(sdmmc_read16(REG_SDRESP2) | (sdmmc_read16(REG_SDRESP3) << 16));
+		ctx->ret[2] = (u32)(sdmmc_read16(REG_SDRESP4) | (sdmmc_read16(REG_SDRESP5) << 16));
+		ctx->ret[3] = (u32)(sdmmc_read16(REG_SDRESP6) | (sdmmc_read16(REG_SDRESP7) << 16));
+	}*/
+}
+
+/* return true if the command is completed and false if it is still ongoing */
+//---------------------------------------------------------------------------------
+bool sdmmc_check_command_ndma(struct mmcdevice *ctx, u32 cmd)
+//---------------------------------------------------------------------------------
+{
+	const bool getSDRESP = (cmd << 15) >> 31;
+    u16 flags = (cmd << 15) >> 31;
+	const bool readdata = cmd & 0x20000;
+	const bool writedata = cmd & 0x40000;
+
+	if(readdata || writedata)
+	{
+		flags |= TMIO_STAT0_DATAEND;
+	}    
+    u16 status0 = 0;
+    
+    volatile u16 status1 = sdmmc_read16(REG_SDSTATUS1);
+    
+    if(status1 & TMIO_MASK_GW)
+	{
+		ctx->error |= 4;
+
+        ctx->stat0 = sdmmc_read16(REG_SDSTATUS0);
+      	ctx->stat1 = sdmmc_read16(REG_SDSTATUS1);
+      	sdmmc_write16(REG_SDSTATUS0,0);
+      	sdmmc_write16(REG_SDSTATUS1,0);
+      
+      	if(getSDRESP != 0)
+      	{
+      		ctx->ret[0] = (u32)(sdmmc_read16(REG_SDRESP0) | (sdmmc_read16(REG_SDRESP1) << 16));
+      		ctx->ret[1] = (u32)(sdmmc_read16(REG_SDRESP2) | (sdmmc_read16(REG_SDRESP3) << 16));
+      		ctx->ret[2] = (u32)(sdmmc_read16(REG_SDRESP4) | (sdmmc_read16(REG_SDRESP5) << 16));
+      		ctx->ret[3] = (u32)(sdmmc_read16(REG_SDRESP6) | (sdmmc_read16(REG_SDRESP7) << 16));
+      	}
+        *(u32*)(0x400411C) = 0x48004000;
+        return true;    
+    }        
+    
+    if(!(status1 & TMIO_STAT1_CMD_BUSY))
+	{
+		status0 = sdmmc_read16(REG_SDSTATUS0);        
+		if(sdmmc_read16(REG_SDSTATUS0) & TMIO_STAT0_CMDRESPEND)
+		{
+			ctx->error |= 0x1;
+		}
+		if(status0 & TMIO_STAT0_DATAEND)
+		{
+			ctx->error |= 0x2;
+		}
+        
+        if((status0 & flags) != flags)
+        {
+            return false;
+        }
+		
+        ctx->stat0 = sdmmc_read16(REG_SDSTATUS0);
+      	ctx->stat1 = sdmmc_read16(REG_SDSTATUS1);
+      	sdmmc_write16(REG_SDSTATUS0,0);
+      	sdmmc_write16(REG_SDSTATUS1,0);
+      
+      	if(getSDRESP != 0)
+      	{
+      		ctx->ret[0] = (u32)(sdmmc_read16(REG_SDRESP0) | (sdmmc_read16(REG_SDRESP1) << 16));
+      		ctx->ret[1] = (u32)(sdmmc_read16(REG_SDRESP2) | (sdmmc_read16(REG_SDRESP3) << 16));
+      		ctx->ret[2] = (u32)(sdmmc_read16(REG_SDRESP4) | (sdmmc_read16(REG_SDRESP5) << 16));
+      		ctx->ret[3] = (u32)(sdmmc_read16(REG_SDRESP6) | (sdmmc_read16(REG_SDRESP7) << 16));
+      	}
+        *(u32*)(0x400411C) = 0x48004000; 
+        return true;
+	} else return false;        
 }
 
 //---------------------------------------------------------------------------------
@@ -690,7 +987,11 @@ int sdmmc_readsectors(struct mmcdevice *device, u32 sector_no, u32 numsectors, v
     sdmmc_write16(REG_SDBLKCOUNT,numsectors);
     device->rData = out;
     device->size = numsectors << 9;
-    sdmmc_send_command_ndma(device,0x33C12,sector_no);
+    device->startOffset = 0;
+    device->endOffset = 0;
+    //sdmmc_send_command(device,0x33C12,sector_no);
+    sdmmc_send_command_nonblocking_ndma(device,0x33C12,sector_no);
+    while(!sdmmc_check_command_ndma(device,0x33C12)) {}
     setTarget(&deviceSD);
     return geterror(device);
 }
@@ -711,6 +1012,8 @@ int sdmmc_writesectors(struct mmcdevice *device, u32 sector_no, u32 numsectors, 
     sdmmc_write16(REG_SDBLKCOUNT,numsectors);
     device->tData = in;
     device->size = numsectors << 9;
+    device->startOffset = 0;
+    device->endOffset = 0;
     sdmmc_send_command(device,0x52C19,sector_no);
     setTarget(&deviceSD);
     return geterror(device);

--- a/source/arm7/sdmmc.twl.c
+++ b/source/arm7/sdmmc.twl.c
@@ -434,9 +434,9 @@ void sdmmc_send_command_nonblocking_ndma(struct mmcdevice *ctx, u32 cmd, u32 arg
             // command is finished already without going busy : return
             // not supposed to happen
             // needed for no$gba only
-            /*status0 = sdmmc_read16(REG_SDSTATUS0);
+            status0 = sdmmc_read16(REG_SDSTATUS0);
             if((status0 & flags) == flags)
-            break;*/
+            break;
 		}		
 	}
 	//ctx->stat0 = sdmmc_read16(REG_SDSTATUS0);


### PR DESCRIPTION
**NOTE:** This PR has been made in response to issue 29 at my GodMode9i repo.
@WinterMute After merging this PR, I will delete my libnds fork.

This PR will slightly speed up SD reads by using NDMA slot 0 on arm7 for SD reads.
Writes will still be handled by the arm7 CPU, because on NDMA side, it's buggy and can cause corruption to whatever file being written.

Credits:
@profi200: Improved SD code.
@ahezard and @shutterbug2000: NDMA part of the SD read code.