### PR TITLE
Remove __packed__ attribute from header structs

### DIFF
--- a/include/nds/memory.h
+++ b/include/nds/memory.h
@@ -243,9 +243,6 @@ typedef struct __DSiHeader {
 
 } tDSiHeader;
 
-#ifdef static_assert
-static_assert(sizeof(tDSiHeader) == 0x1000, "tDSiHeader not packed properly");
-#endif
 
 #define __NDSHeader ((tNDSHeader *)0x02FFFE00)
 #define __DSiHeader ((tDSiHeader *)0x02FFE000)
@@ -263,12 +260,6 @@ typedef struct sNDSBanner {
   u16 palette[16];		//!< the pallete of the icon.
   u16 titles[6][128];	//!< title of the game in 6 different languages.
 } tNDSBanner;
-
-#ifdef static_assert
-static_assert(sizeof(tNDSBanner) == 0x840, "tNDSBanner not packed properly");
-#endif
-
-
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/nds/memory.h
+++ b/include/nds/memory.h
@@ -33,6 +33,7 @@
 #define NDS_MEMORY_INCLUDE
 
 #include "ndstypes.h"
+#include <assert.h>
 
 
 #ifdef ARM9
@@ -107,7 +108,11 @@ typedef struct sGBAHeader {
 	u8 version;			//!< the version of the game.
 	u8 complement;		//!< complement checksum of the gba header.
 	u16 checksum;		//!< a 16 bit checksum? (gbatek says its unused/reserved).
-} __attribute__ ((__packed__)) tGBAHeader;
+} tGBAHeader;
+
+#ifdef static_assert
+static_assert(sizeof(tGBAHeader) == 0xC0, "tGBAHeader not packed properly");
+#endif
 
 #define GBA_HEADER (*(tGBAHeader *)0x08000000)
 
@@ -167,7 +172,11 @@ typedef struct sNDSHeader {
 	u16 logoCRC16;				//!< Nintendo Logo Checksum, CRC-16.
 	u16 headerCRC16;			//!< header checksum, CRC-16.
 
-} __attribute__ ((__packed__)) tNDSHeader;
+} tNDSHeader;
+
+#ifdef static_assert
+static_assert(sizeof(tNDSHeader) == 0x160, "tNDSHeader not packed properly");
+#endif
 
 typedef struct __DSiHeader {
 	tNDSHeader ndshdr;
@@ -240,7 +249,11 @@ typedef struct __DSiHeader {
 	u8 debug_args[0x180];
 	u8 rsa_signature[0x80];
 
-} __attribute__ ((__packed__)) tDSiHeader;
+} tDSiHeader;
+
+#ifdef static_assert
+static_assert(sizeof(tDSiHeader) == 0x1000, "tDSiHeader not packed properly");
+#endif
 
 #define __NDSHeader ((tNDSHeader *)0x02FFFE00)
 #define __DSiHeader ((tDSiHeader *)0x02FFE000)
@@ -257,8 +270,11 @@ typedef struct sNDSBanner {
   u8 icon[512];			//!< 32*32 icon of the game with 4 bit per pixel.
   u16 palette[16];		//!< the pallete of the icon.
   u16 titles[6][128];	//!< title of the game in 6 different languages.
-} __attribute__ ((__packed__)) tNDSBanner;
+} tNDSBanner;
 
+#ifdef static_assert
+static_assert(sizeof(tNDSBanner) == 0x840, "tNDSBanner not packed properly");
+#endif
 
 
 

--- a/include/nds/memory.h
+++ b/include/nds/memory.h
@@ -110,10 +110,6 @@ typedef struct sGBAHeader {
 	u16 checksum;		//!< a 16 bit checksum? (gbatek says its unused/reserved).
 } tGBAHeader;
 
-#ifdef static_assert
-static_assert(sizeof(tGBAHeader) == 0xC0, "tGBAHeader not packed properly");
-#endif
-
 #define GBA_HEADER (*(tGBAHeader *)0x08000000)
 
 /*!
@@ -173,10 +169,6 @@ typedef struct sNDSHeader {
 	u16 headerCRC16;			//!< header checksum, CRC-16.
 
 } tNDSHeader;
-
-#ifdef static_assert
-static_assert(sizeof(tNDSHeader) == 0x160, "tNDSHeader not packed properly");
-#endif
 
 typedef struct __DSiHeader {
 	tNDSHeader ndshdr;


### PR DESCRIPTION
The attribute causes GCC warnings when `-Waddress-of-packed-member` is enabled. It is not needed because the structs are already laid out in a packed way.

To verify that the structs remain as expected, add compile-time asserts.