### PR TITLE
fix bug where save size could be detected incorrectly, if multiple bytes in the save are identical

### DIFF
--- a/source/common/cardEeprom.c
+++ b/source/common/cardEeprom.c
@@ -69,7 +69,6 @@ u32 cardEepromReadID() {
 	return id;
 }
 
-
 //---------------------------------------------------------------------------------
 int cardEepromGetType(void) {
 //---------------------------------------------------------------------------------
@@ -79,7 +78,7 @@ int cardEepromGetType(void) {
 	if (( sr == 0xff && id == 0xffffff) || ( sr == 0 && id == 0 )) return -1;
 	if ( sr == 0xf0 && id == 0xffffff ) return 1;
 	if ( sr == 0x00 && id == 0xffffff ) return 2;
-	if ( id != 0xffffff) return 3;
+	if ( id != 0xffffff || ( sr == 0x02 && id == 0xffffff )) return 3;
 	
 	return 0;
 }
@@ -159,7 +158,13 @@ uint32 cardEepromGetSize() {
 			if (device == 0x2211)
 				return 128*1024;		//	1Mbit(128KByte) - MX25L1021E
 		}
-		
+
+		if (id == 0xffffff) {
+			int sr = cardEepromCommand(SPI_EEPROM_RDSR);
+			if (sr == 2) { // Pokémon Mystery Dungeon - Explorers of Sky
+				return 128*1024; // 1Mbit (128KByte)
+			}
+		}
 
 		return 256*1024;		//	2Mbit(256KByte)
 	}

--- a/source/common/cardEeprom.c
+++ b/source/common/cardEeprom.c
@@ -97,20 +97,26 @@ uint32 cardEepromGetSize() {
 	if(type == 1)
 		return 512;
 	if(type == 2) {
-		u32 buf1,buf2,buf3;
+		u32 buf1,buf2,buf3 = 0x54536554; // "TeST"
+		// Save the first word of the EEPROM
 		cardReadEeprom(0,(u8*)&buf1,4,type);
-		if ( !(buf1 != 0 || buf1 != 0xffffffff) ) {
-			buf3 = ~buf1;
-			cardWriteEeprom(0,(u8*)&buf3,4,type);
-		} else {
-			buf3 = buf1;
-		}
+
+		// Write "TeST" to it
+		cardWriteEeprom(0,(u8*)&buf3,4,type);
+
+		// Loop until the EEPROM mirrors and the first word shows up again
 		int size = 8192;
-		while (1) {	 
+		while (1) {
 			cardReadEeprom(size,(u8*)&buf2,4,type);
 			if ( buf2 == buf3 ) break;
 			size += 8192;
-		};
+		}
+
+		// Restore the first word
+		cardWriteEeprom(0,(u8*)&buf1,4,type);
+
+		return size;
+	}
 
 		if ( buf1 != buf3 ) cardWriteEeprom(0,(u8*)&buf1,4,type);
 

--- a/source/common/cardEeprom.c
+++ b/source/common/cardEeprom.c
@@ -96,18 +96,30 @@ uint32 cardEepromGetSize() {
 	if(type == 1)
 		return 512;
 	if(type == 2) {
-		u32 buf1,buf2,buf3 = 0x54536554; // "TeST"
+		u32 buf1,buf2,buf3 = 0x54534554; // "TEST"
 		// Save the first word of the EEPROM
 		cardReadEeprom(0,(u8*)&buf1,4,type);
 
-		// Write "TeST" to it
+		// Write "TEST" to it
 		cardWriteEeprom(0,(u8*)&buf3,4,type);
 
 		// Loop until the EEPROM mirrors and the first word shows up again
 		int size = 8192;
 		while (1) {
 			cardReadEeprom(size,(u8*)&buf2,4,type);
-			if ( buf2 == buf3 ) break;
+			// Check if it matches, if so check again with another value to ensure no false positives
+			if (buf2 == buf3) {
+				u32 buf4 = 0x74736574; // "test"
+				// Write "test" to the first word
+				cardWriteEeprom(0,(u8*)&buf4,4,type);
+
+				// Check if it still matches
+				cardReadEeprom(size,(u8*)&buf2,4,type);
+				if (buf2 == buf4) break;
+
+				// False match, write "TEST" back and keep going
+				cardWriteEeprom(0,(u8*)&buf3,4,type);
+			}
 			size += 8192;
 		}
 


### PR DESCRIPTION
Recently, a user of GodMode9i reported that it was always dumping only the first 8192 bytes of save, as the function cardEepromGetSize was reporting the wrong value, instead of the 64k which the save should have been. 

Flashing this save to another cartridge also caused the size to be detected incorrectly, so it was nothing with the flash type itself

What causes this here is that both the first and 8192nd words are 0, so it just stops looping early
By writing TeST (a very unlikely value to appear later on) and restoring it after finishing the loop, the size is now detected correctly.



[SCRIBLENAUT2_BH2EWR_0.zip](https://github.com/devkitPro/libnds/files/5872255/SCRIBLENAUT2_BH2EWR_0.zip)
