### PR TITLE
usefully document fifoSendAddress

### DIFF
--- a/include/nds/fifocommon.h
+++ b/include/nds/fifocommon.h
@@ -158,6 +158,7 @@ bool fifoInit();
 	\brief Send an address to an channel.
 
 	Transmits an address in the range 0x02000000-0x023FFFFF to the other CPU.
+	That means any addresses allocated through defined behavior in C, except those returned by memUncached().
 
 	\param channel channel number to send to.
 	\param address address to send.

--- a/include/nds/system.h
+++ b/include/nds/system.h
@@ -411,7 +411,7 @@ struct __argv {
 	int argc;			// internal use, number of arguments
 	char **argv;		// internal use, argv pointer
 	int dummy;			// internal use
-	u32 host;			// internal use, host ip for dslink 
+	u32 host;			// internal use, host ip for dslink
 };
 
 #define __system_argv		((struct __argv *)0x02FFFE70)
@@ -436,6 +436,9 @@ void *memCached(void *address);
 
 /*!
 	\brief returns an uncached mirror of an address.
+
+	The mirror can't be passed to fifoSendAddress().
+
 	\param address an address.
 	\return a pointer to the uncached mirror of that address.
 */


### PR DESCRIPTION
Hi, I had to do dig around and read other people's code to figure out what I can pass to fifoSendAddress, and then while debugging an unrelated bug I printed a pointer and realized that addresses returned by memUncached() have a bit set that puts them out of range for fifoSendAddress, so I think those 2 details should be documented.