### PR TITLE
fix glTexImage2D not flushing data cache

### DIFF
--- a/source/arm9/videoGL.c
+++ b/source/arm9/videoGL.c
@@ -1175,9 +1175,11 @@ int glTexImage2D(int target, int empty1, GL_TEXTURE_TYPE_ENUM type, int sizeX, i
 				src++;
 			}
 		} else {
+			DC_FlushRange(texture, size);
 			dmaCopyWords( 0, texture, tex->vramAddr, size );
 			if( type == GL_COMPRESSED ) {
 				vramSetBankB( VRAM_B_LCD );
+				DC_FlushRange((char*)texture + tex->texSize, size >> 1);
 				dmaCopyWords( 0, (char*)texture + tex->texSize, vramBlock_getAddr( glGlob->vramBlocks[ 0 ], tex->texIndexExt ), size >> 1 );
 			}
 		}


### PR DESCRIPTION
The current glTexImage2D implementation doesn't flush data caches before using `dmaCopyWords`, despite what the `libnds` documentation suggests [here](https://libnds.devkitpro.org/dma_8h.html).

This issue was not reproducible in DeSmuME, I have only encountered it on real hardware (a DSi XL).

Comparison before the change vs after the change.

Before:
![image](https://github.com/devkitPro/libnds/assets/20423431/4ed2ed73-f390-40ba-80d7-b965d12f702e)
After:
![image](https://github.com/devkitPro/libnds/assets/20423431/23f8df84-5dcf-4ec9-9b56-6cf07362bb7e)


This fixes #50