### PR TITLE
Change copyright in dldi and disc_io files to zlib License

### DIFF
--- a/include/nds/arm9/dldi.h
+++ b/include/nds/arm9/dldi.h
@@ -1,29 +1,26 @@
-/*
- dldi.h
+/*------------------------------------------------------------------------------
 
- Copyright (c) 2006 Michael "Chishm" Chisholm
-	
- Redistribution and use in source and binary forms, with or without modification,
- are permitted provided that the following conditions are met:
+dldi.h
 
-  1. Redistributions of source code must retain the above copyright notice,
-     this list of conditions and the following disclaimer.
-  2. Redistributions in binary form must reproduce the above copyright notice,
-     this list of conditions and the following disclaimer in the documentation and/or
-     other materials provided with the distribution.
-  3. The name of the author may not be used to endorse or promote products derived
-     from this software without specific prior written permission.
+Copyright (c) 2006 Michael Chisholm (Chishm)
 
- THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
- AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
- LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1.	The origin of this software must not be misrepresented; you must not
+	claim that you wrote the original software. If you use this software
+	in a product, an acknowledgment in the product documentation would be
+	appreciated but is not required.
+2.	Altered source versions must be plainly marked as such, and must not be
+	misrepresented as being the original software.
+3.	This notice may not be removed or altered from any source distribution.
+
+------------------------------------------------------------------------------*/
 
 
 #ifndef NDS_DLDI_INCLUDE

--- a/include/nds/disc_io.h
+++ b/include/nds/disc_io.h
@@ -1,31 +1,27 @@
-/*
- disc_io.h
- Interface template for low level disc functions.
+/*------------------------------------------------------------------------------
 
- Copyright (c) 2006 Michael "Chishm" Chisholm
- Based on code originally written by MightyMax
-	
- Redistribution and use in source and binary forms, with or without modification,
- are permitted provided that the following conditions are met:
+disc_io.h
+Interface template for low level disc functions.
 
-  1. Redistributions of source code must retain the above copyright notice,
-     this list of conditions and the following disclaimer.
-  2. Redistributions in binary form must reproduce the above copyright notice,
-     this list of conditions and the following disclaimer in the documentation and/or
-     other materials provided with the distribution.
-  3. The name of the author may not be used to endorse or promote products derived
-     from this software without specific prior written permission.
+Copyright (c) 2006 Michael Chisholm (Chishm) and Tim Seidel (Mighty Max).
 
- THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
- AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
- LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1.	The origin of this software must not be misrepresented; you must not
+	claim that you wrote the original software. If you use this software
+	in a product, an acknowledgment in the product documentation would be
+	appreciated but is not required.
+2.	Altered source versions must be plainly marked as such, and must not be
+	misrepresented as being the original software.
+3.	This notice may not be removed or altered from any source distribution.
+
+------------------------------------------------------------------------------*/
 
 #ifndef NDS_DISC_IO_INCLUDE
 #define NDS_DISC_IO_INCLUDE

--- a/source/arm9/dldi/dldi.c
+++ b/source/arm9/dldi/dldi.c
@@ -1,32 +1,28 @@
-/*
- disc.c
- Interface to the low level disc functions. Used by the higher level
- file system code.
- Based on code originally written by MightyMax
+/*------------------------------------------------------------------------------
 
- Copyright (c) 2006 Michael "Chishm" Chisholm
-	
- Redistribution and use in source and binary forms, with or without modification,
- are permitted provided that the following conditions are met:
+disc.c
+Interface to the low level disc functions. Used by the higher level
+file system code.
 
-  1. Redistributions of source code must retain the above copyright notice,
-     this list of conditions and the following disclaimer.
-  2. Redistributions in binary form must reproduce the above copyright notice,
-     this list of conditions and the following disclaimer in the documentation and/or
-     other materials provided with the distribution.
-  3. The name of the author may not be used to endorse or promote products derived
-     from this software without specific prior written permission.
+Copyright (c) 2006 Michael Chisholm (Chishm) and Tim Seidel (Mighty Max).
 
- THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
- WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
- AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE
- LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1.	The origin of this software must not be misrepresented; you must not
+	claim that you wrote the original software. If you use this software
+	in a product, an acknowledgment in the product documentation would be
+	appreciated but is not required.
+2.	Altered source versions must be plainly marked as such, and must not be
+	misrepresented as being the original software.
+3.	This notice may not be removed or altered from any source distribution.
+
+------------------------------------------------------------------------------*/
 
 #include <nds/arm9/dldi.h>
 #include <nds/memory.h>


### PR DESCRIPTION
Align the license of `dldi.h`, `dldi.c` and `disc_io.h` to match the rest of libnds. This is a more permissive license, and will reduce copyright issues that could (have) arise in hobby projects using libnds without reproducing the 3-Clause BSD license.

Additionally, add Tim Seidel to copyright notice in files where he has contributed code.