### PR TITLE
Hardware accelerated floating point operations

### DIFF
--- a/include/nds/arm9/float.h
+++ b/include/nds/arm9/float.h
@@ -1,0 +1,28 @@
+#ifndef FLOATHEADER_H
+#define FLOATHEADER_H
+
+#if defined(__cplusplus)
+extern "C" {                 // Make sure we have C-declarations in C++ programs
+#endif
+
+extern float __wrap___aeabi_fmul( float x, float y);
+extern float __real___aeabi_fmul( float x, float y);
+extern float __aeabi_fmul( float x, float y);
+
+extern float __wrap___aeabi_fdiv( float x, float y);
+extern float __real___aeabi_fdiv( float x, float y);
+extern float __aeabi_fdiv( float x, float y);
+
+
+extern float __wrap_sqrtf( float x);
+extern float __real_sqrtf( float x);
+extern float sqrtf( float x);
+
+//#define sqrtf __wrap_sqrtf
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+

--- a/source/arm9/float.c
+++ b/source/arm9/float.c
@@ -2,7 +2,7 @@
 
 #include "nds.h" 
 
-
+#include "float.h"
 
 #define f32 float
 #define u32 uint32_t

--- a/source/arm9/float.c
+++ b/source/arm9/float.c
@@ -104,10 +104,7 @@ NDS_ITCM_CODE f32 __wrap___aeabi_fmul( f32 x, f32 y){
     mantissa= mantissa & ((1<<23)-1);
     u32 exponent=(combined_exponent+(shift<<23));
     u32 sign= a^b;
-    union{
-    f32 f;
-    u32 k;
-    }result;
+    union{f32 f;u32 k;}result;
     result.k= sign |exponent | mantissa;
     return combined_exponent<=(0<<23)? 0.0:result.f ;
 }

--- a/source/arm9/float.c
+++ b/source/arm9/float.c
@@ -33,7 +33,7 @@ NDS_ITCM_CODE f32 __wrap___aeabi_fdiv(f32 x, f32 y ) {
     REG_DIVCNT = DIV_64_32; 
     REG_DIV_NUMER = (i<<23);
     REG_DIV_DENOM_L = j;
-    s16 shift= i<j ? -1 : 0; 
+    s32 shift= i<j ? -1 : 0; 
     u64 m=(xu.i) & (0xff<<23);
     u64 n=(yu.j) & (0xff<<23);
     s32 exponent=m-n+(shift<<23)+(127<<23);

--- a/source/arm9/float.c
+++ b/source/arm9/float.c
@@ -1,0 +1,113 @@
+
+
+#include "nds.h" 
+
+
+
+#define f32 float
+#define u32 uint32_t
+#define s32 int32_t
+#define u64 uint64_t
+
+
+
+#ifdef TARGET_NDS
+#define NDS_ITCM_CODE __attribute__((section(".itcm")))
+#else
+#define NDS_ITCM_CODE
+#endif
+
+
+//Hardware accelerated floating point operations on the nds, handling of invalid floating point values is not implemented
+// use -Wl,--use-blx,--wrap="__aeabi_fmul",--wrap="__aeabi_fdiv",--wrap="sqrtf" -u sqrtf -u __aeabi_fmul -u __aeabi_fdiv in the linker
+// flags to make the linker replace existing operations with them, or call them directly.
+
+
+NDS_ITCM_CODE f32 __wrap___aeabi_fdiv(f32 x, f32 y ) {
+    union { u32 i; f32 f;}xu;
+    xu.f=x;
+    union {u32 j;f32 f;}yu;
+    yu.f=y;
+    u64 i=((xu.i & ((1<<23)-1))|(1<<23));    
+    u32 j=((yu.j & ((1<<23)-1))|(1<<23));
+    REG_DIVCNT = DIV_64_32; 
+    REG_DIV_NUMER = (i<<23);
+    REG_DIV_DENOM_L = j;
+    s16 shift= i<j ? -1 : 0; 
+    u64 m=(xu.i) & (0xff<<23);
+    u64 n=(yu.j) & (0xff<<23);
+    s32 exponent=m-n+(shift<<23)+(127<<23);
+    u32 a =xu.i & (1<<31);//get sign of x
+    u32 b =yu.j & (1<<31);//get sign of y
+    u32 sign=a^b;
+    if ((exponent<=(0<<23))){
+	while(REG_DIVCNT & DIV_BUSY);
+    return 0.0;
+    } else{
+	while(REG_DIVCNT & DIV_BUSY);
+	u32 mantissa=REG_DIV_RESULT_L;
+	mantissa=shift>=0 ? mantissa>>(shift) : mantissa<<-shift;
+	mantissa=mantissa & ((1<<23)-1);
+	xu.i= sign | exponent | mantissa;
+	return xu.f;
+    }
+}
+
+
+NDS_ITCM_CODE f32 __wrap_sqrtf(f32 x){
+    union{f32 f; u32 i;}xu;
+    xu.f=x;
+    u64 mantissa=xu.i & ((1<<23)-1);
+    //check if exponent is odd
+    //before subtracting 127 exponent was even if it is odd now
+    //therefore check if last digit is 0 
+    mantissa=(mantissa+(1<<23))<<   ( (( xu.i & (1<<23))==0  )      +23 );
+    REG_SQRTCNT = SQRT_64;
+    REG_SQRT_PARAM = mantissa;
+    u32 raw_exponent= (xu.i & (0xff<<23));
+    if (raw_exponent > 0 ) {
+	s32 exponent=raw_exponent-(127<<23);
+	exponent=exponent>>1; //right shift on negative number depends on compiler
+	exponent=((exponent+(127<<23))& (0xff<<23) );
+    //fetch async result here
+	while(REG_SQRTCNT & SQRT_BUSY);
+	xu.i=  exponent| (REG_SQRT_RESULT & ((1<<23)-1));
+	return xu.f;
+    } else{
+	while(REG_SQRTCNT & SQRT_BUSY);
+	return 0.0;
+    };
+
+}
+
+
+NDS_ITCM_CODE f32 __wrap___aeabi_fmul( f32 x, f32 y){
+    union {u32 i;f32 f;}xu;
+    xu.f=x;
+    union {u32 j;f32 f;}yu;
+    yu.f=y;
+    u32 a =xu.i & (1<<31);//get sign of x
+    u32 b =yu.j & (1<<31);//get sign of y
+    s32 exponentx=(xu.i ) &( 0xff<<23);
+    s32 exponenty=(yu.j) &(0xff<<23);
+    if(exponentx==0 || exponenty==0) {
+	return 0.0;
+    }
+    s32 combined_exponent =(exponentx- (127<<23)) +exponenty;
+    u32 i=(xu.i & 0x7fffff); //should be explicit bits of mantissa
+    u32 j=(yu.j & 0x7fffff);
+    u32 mantissa=i+j+(((u64)(i<<4)*(u64)(j<<5))>>32);//this needs to be compiled as ARM code, otherwise the performance sucks
+    mantissa =mantissa +  (1<< 23) ;
+    s32 clz=__builtin_clz(mantissa);
+    s32 shift=8-clz;
+    mantissa= shift>=0 ? mantissa>>shift: mantissa<<-shift;
+    mantissa= mantissa & ((1<<23)-1);
+    u32 exponent=(combined_exponent+(shift<<23));
+    u32 sign= a^b;
+    union{
+    f32 f;
+    u32 k;
+    }result;
+    result.k= sign |exponent | mantissa;
+    return combined_exponent<=(0<<23)? 0.0:result.f ;
+}


### PR DESCRIPTION
Related to #57 .
Please let me know if you need tests of these functions or things like NaN, subnormal number, or overflow handling. These also don't include rounding.
Ideally these should end up as ARM code.
You need
```
-Wl,--use-blx,--wrap="__aeabi_fmul",--wrap="__aeabi_fdiv",--wrap="sqrtf" -u sqrtf -u __aeabi_fmul -u __aeabi_fdiv
```
 in the linker flags if you want the compiler to replace these automatically. You may also need a declaration and/or adding their header file.

The fmul function can technically be shorter by 1 instruction if you do the mantissa multiplication differently, but I looked at the assembly generated and it'd add an interlock after the long multiply  if you use the result in the following clz instruction directly so I dont think it'd help to change it.
I can also add a usage example for nds-examples if needed. A common use case of floating point in general might be evaluation of higher order polynomials, that's the primary reason I added a mul implementation.

If there are any other issues please let me know.

