### PR TITLE
Turn all consoles into devices, allowing Linux VT-like functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs
 warn.log
 *.bz2
 *~
+*.json

--- a/source/arm9/console.c
+++ b/source/arm9/console.c
@@ -34,6 +34,8 @@ distribution.
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/iosupport.h>
 
 
@@ -207,6 +209,12 @@ ssize_t nocash_write(struct _reent *r, void *fd, const char *ptr, size_t len) {
 //---------------------------------------------------------------------------------
 ssize_t con_write(struct _reent *r,void *fd,const char *ptr, size_t len) {
 //---------------------------------------------------------------------------------
+	PrintConsole *tmpConsole = NULL;
+	if (r->deviceData) {
+		// save currentConsole
+		tmpConsole = currentConsole;
+		currentConsole = r->deviceData;
+	}
 
 	char chr;
 
@@ -328,42 +336,27 @@ ssize_t con_write(struct _reent *r,void *fd,const char *ptr, size_t len) {
 		consolePrintChar(chr);
 	}
 
+	if (tmpConsole) {
+		// restore currentConsole
+		currentConsole = tmpConsole;
+	}
+
 	return count;
 }
 
-static const devoptab_t dotab_stdout = {
-	"con",
-	0,
-	NULL,
-	NULL,
-	con_write,
-	NULL,
-	NULL,
-	NULL
-};
+int consoleCount = 1; // Since con0 already exists
 
+static devoptab_t dotab_stdout = {
+	.name = "con0",
+	.write_r = con_write,
+};
 
 static const devoptab_t dotab_nocash = {
-	"nocash",
-	0,
-	NULL,
-	NULL,
-	nocash_write,
-	NULL,
-	NULL,
-	NULL
+	.name = "nocash",
+	.write_r = nocash_write,
 };
 
-static const devoptab_t dotab_null = {
-	"null",
-	0,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL
-};
+extern const devoptab_t dotab_stdnull; // from newlib/libgloss/libsysbase/iosupport.c
 
 //---------------------------------------------------------------------------------
 void consoleLoadFont(PrintConsole* console) {
@@ -488,6 +481,10 @@ _setUpPalette:
 
 }
 
+int con_open(struct _reent *r, void *fileStruct, const char *path, int flags, int mode) {
+	return 0;
+}
+
 //---------------------------------------------------------------------------------
 PrintConsole* consoleInit(PrintConsole* console, int layer,
 				BgType type, BgSize size,
@@ -501,10 +498,40 @@ PrintConsole* consoleInit(PrintConsole* console, int layer,
 		devoptab_list[STD_OUT] = &dotab_stdout;
 		devoptab_list[STD_ERR] = &dotab_stdout;
 
+		// force con0 to also behave like our custom consoles in con_write
+		dotab_stdout.deviceData = console ? console : currentConsole;
+
 		setvbuf(stdout, NULL , _IONBF, 0);
 		setvbuf(stderr, NULL , _IONBF, 0);
 
 		firstConsoleInit = false;
+
+		// WARNING: Only 16 devoptab_list slots are set to dotab_stdnull, but AddDevice() iterates
+		// through to STD_MAX without null-checking... A PR should be put in for this...
+		// https://github.com/devkitPro/newlib/blob/4cc8767a6067786cbb2da969baff3481bd71461c/libgloss/libsysbase/iosupport.c#L107
+		// Temporarily, just to be safe, I'll fix that problem here.
+		for (int i = 16; i < STD_MAX; ++i)
+			devoptab_list[i] = &dotab_stdnull;
+	} else if (console) {
+		// Make a new device for each new console, so that applications can write
+		// to consoles that are not currently being rendered.
+		// The firstConsoleInit code above won't be changed as to not break existing code.
+		devoptab_t *const dot = malloc(sizeof(devoptab_t));
+		dot->write_r = con_write;
+
+		// Set the name to be `con${consoleNumber}`.
+		const int consoleNumber = consoleCount++;
+		dot->name = strdup("con\0\0");
+		sprintf((char *)dot->name + 3, "%d", consoleNumber);
+
+		// Must set an open() callback. newlib returns ENOSYS if not set:
+		// https://github.com/devkitPro/newlib/blob/4cc8767a6067786cbb2da969baff3481bd71461c/libgloss/libsysbase/open.c#L12
+		dot->open_r = con_open;
+
+		// The important part
+		dot->deviceData = console;
+
+		AddDevice(dot);
 	}
 
 	if(console) {
@@ -570,7 +597,7 @@ void consoleDebugInit(DebugDevice device){
 		devoptab_list[STD_ERR] = &dotab_stdout;
 		break;
 	case DebugDevice_NULL:
-		devoptab_list[STD_ERR] = &dotab_null;
+		devoptab_list[STD_ERR] = &dotab_stdnull;
 		break;
 	}
 	setvbuf(stderr, NULL , buffertype, 0);

--- a/source/arm9/console.c
+++ b/source/arm9/console.c
@@ -344,11 +344,16 @@ ssize_t con_write(struct _reent *r,void *fd,const char *ptr, size_t len) {
 	return count;
 }
 
+int con_open(struct _reent *r, void *fileStruct, const char *path, int flags, int mode) {
+	return 0;
+}
+
 int consoleCount = 1; // Since con0 already exists
 
 static devoptab_t dotab_stdout = {
 	.name = "con0",
 	.write_r = con_write,
+	.open_r = con_open,
 };
 
 static const devoptab_t dotab_nocash = {
@@ -481,10 +486,6 @@ _setUpPalette:
 
 }
 
-int con_open(struct _reent *r, void *fileStruct, const char *path, int flags, int mode) {
-	return 0;
-}
-
 //---------------------------------------------------------------------------------
 PrintConsole* consoleInit(PrintConsole* console, int layer,
 				BgType type, BgSize size,
@@ -498,7 +499,8 @@ PrintConsole* consoleInit(PrintConsole* console, int layer,
 		devoptab_list[STD_OUT] = &dotab_stdout;
 		devoptab_list[STD_ERR] = &dotab_stdout;
 
-		// force con0 to also behave like our custom consoles in con_write
+		// make sure con0 also has the new behavior, in case the application
+		// consoleSelects a different console
 		dotab_stdout.deviceData = console ? console : currentConsole;
 
 		setvbuf(stdout, NULL , _IONBF, 0);
@@ -514,7 +516,7 @@ PrintConsole* consoleInit(PrintConsole* console, int layer,
 			devoptab_list[i] = &dotab_stdnull;
 	} else if (console) {
 		// Make a new device for each new console, so that applications can write
-		// to consoles that are not currently being rendered.
+		// to consoles on different bg layers, just like the Linux VTs.
 		// The firstConsoleInit code above won't be changed as to not break existing code.
 		devoptab_t *const dot = malloc(sizeof(devoptab_t));
 		dot->write_r = con_write;

--- a/source/arm9/keyboard.c
+++ b/source/arm9/keyboard.c
@@ -308,18 +308,8 @@ ssize_t keyboardRead(struct _reent *r, void *unused, char *ptr, size_t len) {
 }
 
 const devoptab_t std_in = {
-	"stdin",
-	0,
-	NULL,
-	NULL,
-	NULL,
-	keyboardRead,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL
+	.name = "kb",
+	.read_r = keyboardRead,
 };
 
 


### PR DESCRIPTION
- Closes #69 

## Feature additions
- Creates a new `devoptab_t` for every new console created after the first, named `conN`, where `N` is a monotonically increasing integer starting at 0 for the default console.
- You can `open()` console devices by passing `conN:` as the filename ([the colon is important!](https://github.com/devkitPro/newlib/blob/4cc8767a6067786cbb2da969baff3481bd71461c/libgloss/libsysbase/iosupport.c#L70-L72))
- This also allows the use of the C `FILE *` streams API and C++'s `std::fstream` classes for opening consoles (make sure to disable buffering!)
- Calling `write()` on an opened console file descriptor will simply set `currentConsole` in `console.c` to the attached console passed through `devoptab_t.deviceData`. `currentConsole` is restored after all characters are printed, so that normal use of `stdout`/`stderr` can continue.

## Feature demo/test
Initialize two consoles on **different bg layers AND map bases**, write a simple loop to hide/show the two layers on a button press, open `con0:` and `con1:`, write to the file descriptors, and observe the output on the different consoles by pressing the configured button. (See [here](https://github.com/trustytrojan/nds-shell/blob/d6ffc45f037799b34824d991c7b254d5cc738ce5/src/Commands.cpp#L254-L322) for a more complete test using all bg layers except the last reserved for the keyboard.)

## Backwards compatibility
To keep backwards compatibility, the first initialized console (first call to `consoleInit()`) will still be attached to the `stdout` (1) and `stderr` (2) file descriptors. Its `deviceData` will be set to itself so that you can `open("con0:")` to grab a new file descriptor to that console.

## [Bug discovered in newlib](https://github.com/devkitPro/newlib/blob/4cc8767a6067786cbb2da969baff3481bd71461c/libgloss/libsysbase/iosupport.c#L112-L116)
Not enough `devoptab_list` slots are initially filled with `&dotab_stdnull`, so in `AddDevices()` the loop can dereference a null pointer. In this PR I'm fixing it on the fly on the first `consoleInit()` call (console.c 511-516). I didn't consider it a huge problem worth PR'ing since creating more than 7 consoles is pretty useless, and there arent many other (official) ways to create devices.

## Misc changes
- Removed braced-list initialization of the default `devoptab_t` structs in `console.c` and `keyboard.c`, opting for the cleaner field-setting braced-list initialization. This removes the need to comment every line of the braced-list.
- Changed the default console/keyboard device names to `con0` and `kb` respectively. `kb` (keyboard) makes more sense to see than `stdin` as a device, IMHO.
- Replace `dotab_null` in `console.c` with [`dotab_stdnull` from newlib's `iosupport.c`](https://github.com/devkitPro/newlib/blob/4cc8767a6067786cbb2da969baff3481bd71461c/libgloss/libsysbase/iosupport.c#L22-L53). It already exists so I don't see why we should make a new one.
  - *Off-topic:* Realistically, there should only be one `dotab_stdnull` in `devoptab_list`, and more checks for `NULL` pointers should be in place instead. This would prevent the bug described above.