### PR TITLE
Fix read out-of-bounds when accumulating escape sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs
 warn.log
 *.bz2
 *~
+*.json

--- a/source/arm9/console.c
+++ b/source/arm9/console.c
@@ -321,7 +321,7 @@ ssize_t con_write(struct _reent *r,void *fd,const char *ptr, size_t len) {
 						escaping = false;
 						break;
 				}
-			} while (escaping);
+			} while (escaping && i < len);
 			continue;
 		}
 


### PR DESCRIPTION
- Closes #68
- Caught this bug when I noticed the *same* memory-spilling-onto-the-display crash when letting either libcurl or libssh2 write large buffers with unrecognized escape sequences to the console.